### PR TITLE
Fix reactivity of participants list

### DIFF
--- a/src/MeetingPage.vue
+++ b/src/MeetingPage.vue
@@ -8,8 +8,7 @@
             @resign="resignFromMeeting($event)" 
             @delete="deleteMeeting($event)" 
             :meetings="meetings" 
-            :user-name="userName" 
-            :key="update"></meetings-list>
+            :user-name="userName"></meetings-list>
     </div>
 
 </template>
@@ -32,7 +31,6 @@ export default {
     data() {
         return {
             meetings: [],
-            update: 0,
             newMeeting: false,
         };
     },
@@ -45,21 +43,18 @@ export default {
 
         joinMeeting(meeting) {
             meeting.participants.push(this.userName);
-            this.update++;
         },
 
         resignFromMeeting(meeting) {
             var index;
             index = meeting.participants.indexOf(this.userName);
             meeting.participants.splice(index,1);
-            this.update++; 
         },
 
         deleteMeeting(meeting) {
             var index;
             index = this.meetings.indexOf(meeting);
             this.meetings.splice(index,1);
-            this.update++;
         },
 
         showNewMeetingForm() {

--- a/src/NewMeetingForm.vue
+++ b/src/NewMeetingForm.vue
@@ -21,7 +21,7 @@
 export default {
     data() {
         return {
-            newMeeting: {},
+            newMeeting: {participants: []},
             nameGiven: true
         };
     },
@@ -29,9 +29,8 @@ export default {
     methods: {
         addNewMeeting() {
             if (this.newMeeting.name != null){
-                this.newMeeting.participants = [];
                 this.$emit('added', this.newMeeting);
-                this.newMeeting = {};
+                this.newMeeting = {participants: []};
                 this.nameGiven = true;
             } else {
                 this.nameGiven = false;


### PR DESCRIPTION
Podsyłam dwa commity które odpowiadają na pytanie z moodla:

1. Usuwam to kreatywne obejście z `update` :-)
2. Zobacz, jak w drugim commicie deklaruję pole `participants` wewnątrz obiektu `newMeeting` w formularzu.

Dobrze znalazłeś, że Vue.js będzie reaktywnie odświeżać wszystko co było zadeklarowane w `data()`, ale nie jest prawdą że tylko to co jest w pierwszym poziomie. Jeśli zadeklarujesz tam zagnieżdżony obiekt, który ma tablicę, to ta tablica również będzie reaktywna.

W Twoim rozwiązaniu dodawałeś tę tablicę później, zaraz przed dodaniem spotkania, przez co Vue.js nie "ureaktywniał jej" i nie widział rzeczywiście gdy ona dostawała nowe elementy.

Daj znać, czy teraz działa i czy jest to jasne :-)